### PR TITLE
Include vim-yapf-format.

### DIFF
--- a/.vimrc
+++ b/.vimrc
@@ -90,6 +90,8 @@ Bundle 'lilydjwg/colorizer'
 " numbering every time you go to normal mode. Author refuses to add a setting 
 " to avoid that)
 " Bundle 'myusuf3/numbers.vim'
+" YAPF formatter for Python
+Plugin 'pignacio/vim-yapf-format'
 
 " Plugins from vim-scripts repos:
 
@@ -417,3 +419,10 @@ let g:airline#extensions#whitespace#enabled = 0
 "let g:airline_symbols.branch = '⭠'
 "let g:airline_symbols.readonly = '⭤'
 "let g:airline_symbols.linenr = '⭡'
+
+" YAPF format ------------------------------
+
+" mapping
+map <C-o> :%YapfFormat<CR>
+imap <C-o> <ESC>:YapfFormat<CR>i
+vmap <C-o> :YapfFormat<CR>

--- a/README.rst
+++ b/README.rst
@@ -207,6 +207,8 @@ Most important features include:
 
 * **Paint css color** values with the actual color.
 
+* **Format Python code*** using yapf.
+
 Super easy installation
 -----------------------
 
@@ -219,7 +221,7 @@ Super easy installation
   ::
 
     sudo apt-get install vim exuberant-ctags git
-    sudo pip install dbgp vim-debug pep8 flake8 pyflakes isort
+    sudo pip install dbgp vim-debug pep8 flake8 pyflakes isort yapf
 
   (if you don't have Pip, find it here: `pip <http://pypi.python.org/pypi/pip>`_)
 
@@ -308,6 +310,7 @@ And thanks to all the developers of the plugins that I simply use here:
 * `Visual blocks dragger <https://github.com/fisadev/dragvisuals.vim>`_
 * `Window chooser <https://github.com/t9md/vim-choosewin>`_
 * `Css colors painter <https://github.com/lilydjwg/colorizer>`_
+* `VIM integration for YAPF <https://github.com/pignacio/vim-yapf-format>`_
 
 Optional: fancy symbols and breadcrumbs in the status line
 ----------------------------------------------------------


### PR DESCRIPTION
Include vim-yapf-format so we can format Python code with the Control-o map.