### PR TITLE
Replace kien/ctrlp.vim for the updated version

### DIFF
--- a/.vimrc
+++ b/.vimrc
@@ -39,7 +39,7 @@ Bundle 'scrooloose/nerdcommenter'
 " Class/module browser
 Bundle 'majutsushi/tagbar'
 " Code and files fuzzy finder
-Bundle 'kien/ctrlp.vim'
+Bundle 'ctrlpvim/ctrlp.vim'
 " Extension to ctrlp, for fuzzy command finder
 Bundle 'fisadev/vim-ctrlp-cmdpalette'
 " Zen coding


### PR DESCRIPTION
kien/ctrlp.vim is no longer maintainer (see README) so the same author encourages to go with the up-to-date plugin ctrlpvim/ctrlp.vim